### PR TITLE
repo.cmd unnecessary bash call fix - call python directly instead

### DIFF
--- a/repo.cmd
+++ b/repo.cmd
@@ -1,1 +1,1 @@
-@bash -c "repo %*"
+@call python %~dp0\repo %*


### PR DESCRIPTION
Python already needs to be in the path for repo to run, spawning a bash shell to run python seems like an unnecessary additional step.