### PR TITLE
Fixed push subcmd and alligned to upload

### DIFF
--- a/subcmds/push.py
+++ b/subcmds/push.py
@@ -376,9 +376,15 @@ in all projects listed in the manifest.
       if avail:
         pending.append((project, avail))
 
-    if pending and (not opt.bypass_hooks):
+    if not pending:
+      print("no branches ready for upload", file=sys.stderr)
+      return
+
+    if not opt.bypass_hooks:
       hook = RepoHook('pre-push', self.manifest.repo_hooks_project,
-                      self.manifest.topdir, abort_if_user_denies=True)
+                      self.manifest.topdir,
+                      self.manifest.manifestProject.GetRemote('origin').url,
+                      abort_if_user_denies=True)
       pending_proj_names = [project.name for (project, avail) in pending]
       pending_worktrees = [project.worktree for (project, avail) in pending]
       try:


### PR DESCRIPTION
The push command broke due to a changed signature of RepoHook. The check for pending upload is just aligned to upload(.py). 