### PR TITLE
Use Python27 if installed, and quote %~dp0

### DIFF
--- a/repo.cmd
+++ b/repo.cmd
@@ -1,1 +1,6 @@
-@call python %~dp0\repo %*
+@echo off
+setlocal
+set PYTHON_EXE=python
+if exist C:\Python27\python.exe set PYTHON_EXE=C:\Python27\python.exe
+call %PYTHON_EXE% "%~dp0\repo" %*
+endlocal


### PR DESCRIPTION
Fixed #42 and also prefers a Python 2.7 installation from `C:\Python27` by default if one exists. This breaks hacking on `repo`'s Python 3 support using `repo.cmd`, which I think is reasonable in order to have it work out-of-the-box for more people.