### PR TITLE
Open HEAD file in wb mode to preserve the LF

### DIFF
--- a/project.py
+++ b/project.py
@@ -56,7 +56,7 @@ else:
 def _lwrite(path, content):
   lock = '%s.lock' % path
 
-  fd = open(lock, 'w')
+  fd = open(lock, 'wb')
   try:
     fd.write(content)
   finally:


### PR DESCRIPTION
During repo start command the .git/HEAD file is recreated from a string ending with LF,
Under windows this is converted to CRLF. Then the git command to retreive the HEAD fail.
The __git_ps1 also fail at correctly detect the name if CRLF is present instead of LF

After this correction all repo start correctly create the branches without __git_ps1
erroneous display. The closing parenthesis was missing at end of line and set at beginning.
In addition, All repo push command correctly behaves.